### PR TITLE
Removes duplicity with parent .eslintrc.json

### DIFF
--- a/projects/systelab-preferences/.eslintrc.json
+++ b/projects/systelab-preferences/.eslintrc.json
@@ -14,54 +14,7 @@
           "projects/systelab-preferences/tsconfig.spec.json"
         ],
         "createDefaultProgram": true
-      },
-      "rules": {
-        "@angular-eslint/component-selector": [
-          "error",
-          {
-            "type": "element",
-            "prefix": "app",
-            "style": "kebab-case"
-          }
-        ],
-        "@angular-eslint/directive-selector": [
-          "error",
-          {
-            "type": "attribute",
-            "prefix": "app",
-            "style": "camelCase"
-          }
-        ],
-        "@typescript-eslint/consistent-type-definitions": "error",
-        "@typescript-eslint/dot-notation": "off",
-        "@typescript-eslint/explicit-member-accessibility": [
-          "off",
-          {
-            "accessibility": "explicit"
-          }
-        ],
-        "@typescript-eslint/no-use-before-define": "error",
-        "brace-style": [
-          "error",
-          "1tbs"
-        ],
-        "id-blacklist": "off",
-        "id-match": "off",
-        "max-len": [
-          "error",
-          {
-            "code": 180
-          }
-        ],
-        "no-underscore-dangle": "off",
-        "valid-typeof": "error"
       }
-    },
-    {
-      "files": [
-        "*.html"
-      ],
-      "rules": {}
     }
   ]
 }


### PR DESCRIPTION
# PR Details

Migration from TSLint to ESLinit (#41)

Removes duplicity with parent .eslintrc.json


## Motivation and Context

Remove duplicity

## How Has This Been Tested

Lint execution: ng lint?
Errors shown by IntelliJ/Webstorm?

## Types of changes

Dependency upgrade: Lint migration